### PR TITLE
fix: corrige o .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-MONGO_URL="mongodb://admin:pass@localhost:27017"
+MONGO_URL="mongodb://admin:pass@db-pagamentos:27017/"
 
 # API de Pedidos
 BASE_URL_API_PEDIDOS=http://localhost:3002/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       IDEMPOTENCY_KEY_MERCADOPAGO: ${IDEMPOTENCY_KEY_MERCADOPAGO:-a005986e-f97c-4274-91cf-b32d2672824f}
     restart: always
     networks:
-      - default
+      - rms
     depends_on:
       - db-pagamentos
   
@@ -41,6 +41,8 @@ services:
           memory: 1024M
         reservations:
           memory: 1024M
+    networks:
+      - rms
 
   mongo-express:
     container_name: mongo-express
@@ -61,7 +63,10 @@ services:
           memory: 1024M
         reservations:
           memory: 1024M
+    networks:
+      - rms
           
 networks:
-  default:
+  rms:
+    name: rms_network
     driver: bridge

--- a/src/infrastructure/mongo/mongo-data-services.module.ts
+++ b/src/infrastructure/mongo/mongo-data-services.module.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '@nestjs/config';
       inject: [ConfigService], // Injete o ConfigService
       useFactory: async (configService: ConfigService) => ({
         uri: configService.get<string>('MONGO_URL'), // Use o ConfigService para obter a variável de ambiente
-        dbName: 'pagamento',
+        dbName: 'pagamentos',
       }),
     }),
     // MongooseModule.forRoot('mongodb://admin:pass@localhost:27017', {


### PR DESCRIPTION
- Pequena correção no arquivo `.env.template`
- Coloca o `dbName` no plural para manter o padrão, seguindo os demais microsserviços
- Definindo um nome para a rede do docker compose para que um microsserviço em uma stack do docker compose possa chamar microsserviços em outras stacks do docker compose.