### PR TITLE
test: testes unitários services de infra

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
 MONGO_URL="mongodb://admin:pass@db-pagamentos:27017/"
 
 # API de Pedidos
-BASE_URL_API_PEDIDOS=http://localhost:3002/
+URL_API_PEDIDOS=http://localhost:3002/pedido
 
 # Mercado Pago
 ACCESS_TOKEN_MERCADOPAGO=

--- a/src/application/use_cases/pedido/pedido.use_case.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.ts
@@ -38,7 +38,6 @@ export class PedidoUseCase implements IPedidoUseCase {
     const qrData = await this.gatewayPagamentoService.criarPedido(pedido);
     pedidoDTO.qrCode = qrData;
 
-    // TODO: Gravar no MongoDB o pedido.id e o respectivo QR Code gerado pelo Mercado Pago
     await this.pedidoRepository.registrarQRCode(pedido.id, qrData, new Date());
 
     return {
@@ -53,7 +52,6 @@ export class PedidoUseCase implements IPedidoUseCase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mensagem: MensagemMercadoPagoDTO,
   ): Promise<any> {
-    // TODO: Gravar no MongoDB os parâmentros id, topic e mensagem que recebemos do Mercado Pago, para auditoria
     await this.pedidoRepository.guardarMsgWebhook(id, topic);
 
     if (id && topic === 'merchant_order') {

--- a/src/application/use_cases/webhook/webhook.use_case.ts
+++ b/src/application/use_cases/webhook/webhook.use_case.ts
@@ -28,7 +28,6 @@ export class WebhookUseCase implements IWebhookUseCase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     //mensagem: MensagemMercadoPagoDTO,
   ): Promise<any> {
-    // TODO: Gravar no MongoDB os parâmentros id, topic e mensagem que recebemos do Mercado Pago, para auditoria
     await this.pedidoRepository.guardarMsgWebhook(id, topic);
 
     if (id && topic === 'merchant_order') {

--- a/src/infrastructure/mongo/mongo-data-services.service.ts
+++ b/src/infrastructure/mongo/mongo-data-services.service.ts
@@ -3,8 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { MongoGenericRepository } from './mongo-generic-repository';
 
-import { Pagamento } from './model/pagamento.entity'; //core dto domain
-import { PagamentoDocument } from './model/pagamento.entity'; //model entity
+import { Pagamento, PagamentoDocument } from './model/pagamento.entity';
 import { IDataServices } from 'src/abstracts';
 import { RetornoMP, RetornoMPDocument } from './model/retorno_mp.entity';
 

--- a/src/infrastructure/services/api_pedidos/apipedidos.service.spec.ts
+++ b/src/infrastructure/services/api_pedidos/apipedidos.service.spec.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiPedidosService } from './apipedidos.service';
+import { pedidoResponseMock } from 'src/mocks/pedido.mock';
+
+describe('ApiPedidosService', () => {
+  let apiPedidosService: ApiPedidosService;
+  let configService: ConfigService;
+  let pedidoId: string;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiPedidosService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    apiPedidosService = module.get<ApiPedidosService>(ApiPedidosService);
+    configService = module.get<ConfigService>(ConfigService);
+    pedidoId = '0a14aa4e-75e7-405f-8301-81f60646c93d';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve atualizar status de um pedido', async () => {
+    jest.spyOn(configService, 'get').mockReturnValue('http://localhost:3000');
+
+    jest.spyOn(axios, 'put').mockResolvedValue({
+      data: {
+        body: pedidoResponseMock,
+      },
+    });
+
+    expect(
+      apiPedidosService.atualizarStatusPedido(pedidoId),
+    ).resolves.not.toThrow();
+  });
+
+  it('deve lançar uma exceção ao atualizar status de um pedido', async () => {
+    jest.spyOn(configService, 'get').mockReturnValue('http://localhost:3000');
+
+    jest.spyOn(axios, 'put').mockRejectedValue(new Error('Erro'));
+
+    await expect(
+      apiPedidosService.atualizarStatusPedido(pedidoId),
+    ).rejects.toThrow('Ocorreu um erro ao atualizar o status do pedido.');
+  });
+});

--- a/src/infrastructure/services/api_pedidos/apipedidos.service.ts
+++ b/src/infrastructure/services/api_pedidos/apipedidos.service.ts
@@ -5,37 +5,20 @@ import axios from 'axios';
 
 @Injectable()
 export class ApiPedidosService implements IApiPedidosService {
-  private _baseUrlApiPedidos: string;
+  private _urlApiPedidos: string;
 
   constructor(private configService: ConfigService) {
-    this._baseUrlApiPedidos = this.configService.get<string>(
-      'BASE_URL_API_PEDIDOS',
-    );
+    this._urlApiPedidos = this.configService.get<string>('URL_API_PEDIDOS');
   }
 
   async atualizarStatusPedido(idPedido: string): Promise<void> {
-    const data = JSON.stringify({
-      pago: true,
-      statusPedido: 'em preparacao',
-    });
-
-    const config = {
-      method: 'put',
-      maxBodyLength: Infinity,
-      url: `${this._baseUrlApiPedidos}/pedido/${idPedido}`,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: data,
-    };
-
-    await axios
-      .request(config)
-      .then((response) => {
-        console.log(JSON.stringify(response.data));
-      })
-      .catch((error) => {
-        console.log(error);
+    try {
+      await axios.put(`${this._urlApiPedidos}/${idPedido}`, {
+        pago: true,
+        statusPedido: 'em_preparacao',
       });
+    } catch (error) {
+      throw new Error('Ocorreu um erro ao atualizar o status do pedido.');
+    }
   }
 }

--- a/src/infrastructure/services/gateway_pagamentos/gatewaypag.service.spec.ts
+++ b/src/infrastructure/services/gateway_pagamentos/gatewaypag.service.spec.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { GatewayMercadoPagoService } from './gatewaypag.service';
+import {
+  configServiceMock,
+  mercadoPagoResponseMock,
+  pedidoEntityMock,
+} from 'src/mocks/pedido.mock';
+
+describe('GatewayMercadoPagoService', () => {
+  let gatewayMercadoPagoService: GatewayMercadoPagoService;
+  let qrData: string;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GatewayMercadoPagoService,
+        {
+          provide: ConfigService,
+          useValue: configServiceMock,
+        },
+      ],
+    }).compile();
+
+    gatewayMercadoPagoService = module.get<GatewayMercadoPagoService>(
+      GatewayMercadoPagoService,
+    );
+    qrData =
+      '00020101021243650016COM.MERCADOLIBRE02013063638f1192a-5fd1-4180-a180-8bcae3556bc35204000053039865802BR5925IZABEL AAAA DE MELO6007BARUERI62070503***63040B6D';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve criar um pedido no mercado pago', async () => {
+    jest.spyOn(axios, 'request').mockResolvedValue({
+      data: mercadoPagoResponseMock,
+    });
+
+    const result =
+      await gatewayMercadoPagoService.criarPedido(pedidoEntityMock);
+
+    expect(result).toStrictEqual(qrData);
+  });
+});

--- a/src/mocks/pedido.mock.ts
+++ b/src/mocks/pedido.mock.ts
@@ -78,6 +78,68 @@ pedidoDTOMock.pago = false;
 pedidoDTOMock.statusPedido = pedidoModelMock.statusPedido;
 pedidoDTOMock.qrCode = null;
 
+export const configServiceMock = {
+  get: jest.fn((key: string) => {
+    if (key === 'ACCESS_TOKEN_MERCADOPAGO') {
+      return 'TEST-844********54504-01********443991c5********a5b5e4db********5758942';
+    }
+    if (key === 'EXTERNAL_POS_ID_MERCADOPAGO') {
+      return 'CAIXA01';
+    }
+    if (key === 'WEBHOOK_URL_MERCADOPAGO') {
+      return 'https://www.example.com/';
+    }
+    if (key === 'IDEMPOTENCY_KEY_MERCADOPAGO') {
+      return '0e4990a0-cbac-417a-94f2-a22be7ae9179';
+    }
+  }),
+};
+
+export const pedidoResponseMock = {
+  mensagem: 'Pedido atualizado com sucesso',
+  body: {
+    qrCode: null,
+    id: '5c20b15a-247c-4544-9d6c-1474ad46b16d',
+    numeroPedido: '44191',
+    itensPedido: [
+      {
+        id: 'fbdfaec9-a4a9-447e-9966-f0b07723aa7d',
+        quantidade: 1,
+        produto: {
+          id: '4511aa20-90b2-45ae-bbf8-3ab05ec85983',
+          nome: 'X-tudo',
+          descricao:
+            'Ingredientes: 1 Hambúrguer, 50 G De Bacon Picados, 1 Ovo, 2 Fatias De Presunto, 2 Fatias De Mussarela (cheddar), 1 Folha De Alface, 1 Rodela De Tomate, 1 Pão De Hambúrguer, 1 Colher De Maionese, Catchup A Gosto (opcional)',
+          valorUnitario: 29.9,
+          imagemUrl:
+            'https://conteudo.imguol.com.br/c/entretenimento/17/2023/05/24/x-tudo-brasileiro-tem-variedade-de-ingredientes-de-acordo-com-preferencias-regionais-aqui-versao-com-carne-bovina-tomato-salsicha-presunto-bacon-e-queijo-no-pao-1684938396547_v2_1x1.jpg',
+          categoria: {
+            id: '43a7f9e1-632b-4cb6-b7d7-38e1004f2a9c',
+            nome: 'Lanches',
+            descricao: 'Lanches Para Todos Os Gostos!',
+          },
+        },
+      },
+    ],
+    pago: true,
+    statusPedido: 'em preparacao',
+    criadoEm: '2024-05-10T04:26:59.959Z',
+    atualizadoEm: '2024-05-10T04:27:21.049Z',
+    cliente: {
+      id: '88639b90-a9cf-4703-9735-7ab2ff02299b',
+      nome: 'Cliente Anônimo',
+      email: 'cliente@anonimo.com',
+      cpf: '00000000191',
+    },
+  },
+};
+
+export const mercadoPagoResponseMock = {
+  qr_data:
+    '00020101021243650016COM.MERCADOLIBRE02013063638f1192a-5fd1-4180-a180-8bcae3556bc35204000053039865802BR5925IZABEL AAAA DE MELO6007BARUERI62070503***63040B6D',
+  in_store_order_id: 'd4e8ca59-3e1d-4c03-b1f6-580e87c654ae',
+};
+
 export const mensagemGatewayPagamentoDTO = new MensagemMercadoPagoDTO();
 mensagemGatewayPagamentoDTO.resource =
   'https://api.mercadolibre.com/merchant_orders/15171882961';

--- a/src/presentation/rest/v1/controllers/webhook/webhook.controller.spec.ts
+++ b/src/presentation/rest/v1/controllers/webhook/webhook.controller.spec.ts
@@ -50,7 +50,7 @@ describe('WebhookController', () => {
       new NotFoundException('Pedido não encontrado'),
     );
 
-    await expect(controller.consumirMensagem(id, topic)).rejects.toThrowError(
+    await expect(controller.consumirMensagem(id, topic)).rejects.toThrow(
       NotFoundException,
     );
   });


### PR DESCRIPTION
Implementando testes unitários para as Services de infrastructure, para aumentar a cobertura de testes na API de Pagamentos.

Card #120 do Trello
https://trello.com/c/g4wnuOq1/120-implementar-mais-cen%C3%A1rios-de-testes-unit%C3%A1rios-na-api-de-pagamentos-at%C3%A9-atingir-80-de-cobertura