### PR TITLE
feat: preenche svc da API pag no ConfigMap

### DIFF
--- a/k8s/production/bff/config.yaml
+++ b/k8s/production/bff/config.yaml
@@ -8,5 +8,5 @@ metadata:
 data:
   DB_NAME: "pagamentos"
   DB_SSL: "false"
-  URL_API_PEDIDOS: ""
+  URL_API_PEDIDOS: "http://rms-api-pedidos.rms.svc.cluster.local:80/pedido"
   IDEMPOTENCY_KEY_MERCADOPAGO: "a005986e-f97c-4274-91cf-b32d2672824f"

--- a/src/infrastructure/services/api_pedidos/apipedidos.service.ts
+++ b/src/infrastructure/services/api_pedidos/apipedidos.service.ts
@@ -14,7 +14,7 @@ export class ApiPedidosService implements IApiPedidosService {
   async atualizarStatusPedido(idPedido: string): Promise<void> {
     try {
       await axios.put(`${this._urlApiPedidos}/${idPedido}`, {
-        pago: true,
+        statusPagamento: 'pago',
         statusPedido: 'em_preparacao',
       });
     } catch (error) {


### PR DESCRIPTION
- Preenchendo o endereço da service da API de Pedidos no ConfigMap do k8s.
- Correção de bug.