### PR TITLE
feat(140): Reduz prazo de validade dos QR Codes

### DIFF
--- a/src/infrastructure/services/gateway_pagamentos/gatewaypag.service.ts
+++ b/src/infrastructure/services/gateway_pagamentos/gatewaypag.service.ts
@@ -36,7 +36,7 @@ export class GatewayMercadoPagoService implements IGatewayPagamentoService {
     // Criar um novo Pedido do Mercado Pago
     const dataValidadeQrCode = DateTime.now()
       .setZone('UTC')
-      .plus({ hours: 24 })
+      .plus({ minutes: 5 })
       .toISO();
     const itensPedidoMercadoPago = this.gerarItensPedidoMercadoPago(
       pedido.itensPedido,


### PR DESCRIPTION
Reduzindo o prazo de validade dos QR Codes de 24 horas para 15 minutos, conforme sugestão do @joao0812 