### PR TITLE
feat(140): Aumenta prazo de validade dos QR Codes

### DIFF
--- a/src/infrastructure/services/gateway_pagamentos/gatewaypag.service.ts
+++ b/src/infrastructure/services/gateway_pagamentos/gatewaypag.service.ts
@@ -48,7 +48,7 @@ export class GatewayMercadoPagoService implements IGatewayPagamentoService {
 
     const dataValidadeQrCode = DateTime.now()
       .setZone('UTC')
-      .plus({ minutes: 5 })
+      .plus({ minutes: 15 })
       .toISO();
     const itensPedidoMercadoPago = this.gerarItensPedidoMercadoPago(
       pedido.itensPedido,


### PR DESCRIPTION
Precisei aumentar um pouco o prazo de validade dos QR Codes de `5 minutos` para `15 minutos`, pois 5 minutos estava vencendo muito rápido e na hora de gravar o vídeo provavelmente vai vencer antes que eu consiga fazer o pagamento, quando estiver explicando o código.